### PR TITLE
Ensure CSS elements are not duplicated

### DIFF
--- a/discord-overlay
+++ b/discord-overlay
@@ -210,7 +210,7 @@ class Overlay(QtCore.QObject):
             self.delCSS('cssflexybox')
 
     def addCSS(self,name,css):
-        js = '(function() { css = document.createElement(\'style\');css.type=\'text/css\';css.id=\'%s\';document.head.appendChild(css);css.innerText=\'%s\';})()' % (name,css)
+        js = '(function() { css = document.getElementById(\'%s\'); if (css == null) { css = document.createElement(\'style\'); css.type=\'text/css\'; css.id=\'%s\'; document.head.appendChild(css); } css.innerText=\'%s\';})()' % (name, name, css)
         self.overlay.page().runJavaScript(js)
 
     def delCSS(self,name):


### PR DESCRIPTION
> This fixes a particular bug where you can enable CSS A and CSS B, then
> disable CSS A, but CSS A would not be actually removed until the next
> tweaks update (i.e. enabling or disabling some other CSS).

\- commit text

Example you can see quite easily: show a voice chat overlay, check the "right align" box, check and uncheck the "show mute and deafen" box a few times, then uncheck "right align". The effects of unchecking "right align" will only appear after clicking "show mute and deafen" a few more times.